### PR TITLE
[FEAT] Add localization to Dropdown Options

### DIFF
--- a/apps/web/src/app/api/user/meal-history/route.ts
+++ b/apps/web/src/app/api/user/meal-history/route.ts
@@ -90,7 +90,7 @@ export async function GET() {
       .select(
         `
         *,
-        dish_sum_view ( 
+        dish_sum_mat_view ( 
         *
         )
       `,
@@ -99,8 +99,9 @@ export async function GET() {
 
     const formattedData = data?.map((meal) => ({
       ...meal,
-      ...meal.dish_sum_view,
-      dish_sum_view: undefined,
+      ...meal.dish_sum_mat_view,
+      dish_sum_mat_view: undefined,
+      id: meal.id!,
     }));
 
     if (error) {

--- a/apps/web/src/components/Setup/SetupForm.tsx
+++ b/apps/web/src/components/Setup/SetupForm.tsx
@@ -25,7 +25,9 @@ export default function SetupForm({ locale, messages }: SetupFormProps) {
   const [weight, setWeight] = useState("");
   const [height, setHeight] = useState("");
   const [sex, setSex] = useState("");
+  const [sexDisplay, setSexDisplay] = useState("");
   const [activityLevel, setActivityLevel] = useState("");
+  const [activityLevelDisplay, setActivityLevelDisplay] = useState("");
   const [dietary, setDietary] = useState<string[]>([]);
   const [goal, setGoal] = useState("");
 
@@ -176,12 +178,14 @@ export default function SetupForm({ locale, messages }: SetupFormProps) {
         header={t("sex_header", messages)}
         placeholder={t("sex_placeholder", messages)}
         type="dropdown"
-        options={["Male", "Female"]}
+        options={{ Male: t("male", messages), Female: t("female", messages) }}
         value={sex}
         onChange={(val) => {
           setSex(val);
           validateField("sex", val);
         }}
+        onDropDownNameChange={(name) => setSexDisplay(name)}
+        dropDownName={sexDisplay}
         error={errors.sex}
       />
 
@@ -189,18 +193,20 @@ export default function SetupForm({ locale, messages }: SetupFormProps) {
         header={t("activity_level_header", messages)}
         placeholder={t("activity_level_placeholder", messages)}
         type="dropdown"
-        options={[
-          "Sedentary (little to no exercise)",
-          "Lightly active (1-3 days per week)",
-          "Moderately active (3-5 days per week)",
-          "Very active (5-7 days per week)",
-          "Extra active (Very hard exercise or twice a day)",
-        ]}
+        options={{
+          Sedentary: t("sedentary", messages),
+          LightlyActive: t("lightly_active", messages),
+          ModeratelyActive: t("moderately_active", messages),
+          VeryActive: t("very_active", messages),
+          ExtraActive: t("extra_active", messages),
+        }}
         value={activityLevel}
         onChange={(val) => {
           setActivityLevel(val);
           validateField("activityLevel", val);
         }}
+        onDropDownNameChange={(name) => setActivityLevelDisplay(name)}
+        dropDownName={activityLevelDisplay}
         error={errors.activityLevel}
       />
 

--- a/apps/web/src/components/Shared/Input.tsx
+++ b/apps/web/src/components/Shared/Input.tsx
@@ -18,8 +18,10 @@ interface InputProps {
   frontImageURL?: string;
   backImageURL?: string;
   unit?: string;
-  options?: string[];
+  options?: Record<string, string>;
   error?: string;
+  onDropDownNameChange?: (name: string) => void;
+  dropDownName?: string;
 }
 
 export function InputHeader({ header, subheader }: InputHeaderProps) {
@@ -41,10 +43,12 @@ export function Input({
   backImageURL,
   unit,
   type,
-  options = [],
+  options = {},
   value = "",
   error = "",
   onChange,
+  onDropDownNameChange = () => {},
+  dropDownName = "",
 }: InputProps) {
   const [isOpen, setIsOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
@@ -105,8 +109,12 @@ export function Input({
             </div>
           ) : (
             <div className="flex w-full items-center justify-between py-4 leading-4">
-              <span className={value === "" ? "text-grey-40" : "text-grey-100"}>
-                {value === "" ? placeholder : value}
+              <span
+                className={
+                  dropDownName === "" ? "text-grey-40" : "text-grey-100"
+                }
+              >
+                {dropDownName === "" ? placeholder : dropDownName}
               </span>
               <Image
                 src="/Icons/Dropdown.svg"
@@ -132,16 +140,17 @@ export function Input({
         {/* Dropdown Menu */}
         {type === "dropdown" && isOpen && (
           <div className="border-grey-20 bg-background-1 absolute top-full left-0 z-50 mt-2 w-full overflow-hidden rounded-xl border-[1.5px] shadow-md">
-            {options.map((opt, index) => (
+            {Object.entries(options).map(([value, name], index) => (
               <div
-                key={`${opt}-${index}`}
+                key={`${value}-${index}`}
                 onClick={() => {
-                  onChange(opt);
+                  onChange(value);
+                  onDropDownNameChange(name);
                   setIsOpen(false);
                 }}
                 className="border-grey-20 text-grey-100 hover:bg-green-10 cursor-pointer border-b px-5 py-4 text-sm transition-colors last:border-b-0 hover:text-green-100"
               >
-                {opt}
+                {name}
               </div>
             ))}
           </div>

--- a/apps/web/src/constants/SetupSchema.tsx
+++ b/apps/web/src/constants/SetupSchema.tsx
@@ -3,11 +3,11 @@ import { z } from "zod";
 export const SEX_OPTIONS = ["Male", "Female"] as const;
 
 export const ACTIVITY_LEVEL_OPTIONS = [
-  "Sedentary (little to no exercise)",
-  "Lightly active (1-3 days per week)",
-  "Moderately active (3-5 days per week)",
-  "Very active (5-7 days per week)",
-  "Extra active (Very hard exercise or twice a day)",
+  "Sedentary",
+  "LightlyActive",
+  "ModeratelyActive",
+  "VeryActive",
+  "ExtraActive",
 ] as const;
 
 export const DIETARY_OPTIONS = [

--- a/apps/web/src/locales/en/Setup/SetupForm.json
+++ b/apps/web/src/locales/en/Setup/SetupForm.json
@@ -11,11 +11,18 @@
   "height_header": "Height (cm)",
   "height_placeholder": "Value",
 
-  "sex_header": "Sex",
+  "sex_header": "Sex assigned at birth",
   "sex_placeholder": "What is your sex?",
+  "male": "Male",
+  "female": "Female",
 
   "activity_level_header": "Activity Level",
   "activity_level_placeholder": "How active are you?",
+  "sedentary": "Sedentary (little to no exercise)",
+  "lightly_active": "Lightly active (1-3 days per week)",
+  "moderately_active": "Moderately active (3-5 days per week)",
+  "very_active": "Very active (5-7 days per week)",
+  "extra_active": "Extra active (Very hard exercise or twice a day)",
 
   "dietary_header": "Dietary Restrictions",
   "dietary_subheader": "Please select all that apply to you.",

--- a/apps/web/src/locales/th/Setup/SetupForm.json
+++ b/apps/web/src/locales/th/Setup/SetupForm.json
@@ -11,11 +11,18 @@
   "height_header": "ส่วนสูง (ซม.)",
   "height_placeholder": "ระบุตัวเลข",
 
-  "sex_header": "เพศ",
+  "sex_header": "เพศกำเนิด",
   "sex_placeholder": "ระบุเพศของคุณ",
+  "male": "ชาย",
+  "female": "หญิง",
 
   "activity_level_header": "ระดับกิจกรรม",
   "activity_level_placeholder": "คุณขยับร่างกายบ่อยแค่ไหน?",
+  "sedentary": "ออกกำลังกายน้อยมากหรือไม่เลย",
+  "lightly_active": "เบาบาง (1 - 3 วันต่อสัปดาห์)",
+  "moderately_active": "ปานกลาง (3-5 วันต่อสัปดาห์)",
+  "very_active": "มาก (5-7 วันต่อสัปดาห์)",
+  "extra_active": "มากเป็นพิเศษ (ออกกำลังกายหนักมากหรือวันละสองครั้ง)",
 
   "dietary_header": "ข้อจำกัดด้านอาหาร",
   "dietary_subheader": "โปรดเลือกข้อมูลที่ตรงกับคุณ",


### PR DESCRIPTION
## Description

- added localization to dropdown options

## Changes Made

- edited Input, SetupForm, and activity level options type

## Screenshots
<img width="578" height="693" alt="image" src="https://github.com/user-attachments/assets/eef42314-8e81-41bc-9308-cd0881330f2b" />

## Example Usage

see example in `SetupForm.tsx`.
1. create 2 useStates for value (actual value used in system and types) and name (displayed in UI for user)
```typescript
const [activityLevel, setActivityLevel] = useState("");
const [activityLevelDisplay, setActivityLevelDisplay] = useState("");
```

2. Add `options` field as Record<string, string>, also `onDropDownNameChange` and `dropDownName`:
```typescript
<Input
        header={t("activity_level_header", messages)}
        placeholder={t("activity_level_placeholder", messages)}
        type="dropdown"
        options={{
          Sedentary: t("sedentary", messages),
          LightlyActive: t("lightly_active", messages),
          ModeratelyActive: t("moderately_active", messages),
          VeryActive: t("very_active", messages),
          ExtraActive: t("extra_active", messages),
        }}
        value={activityLevel}
        onChange={(val) => {
          setActivityLevel(val);
          validateField("activityLevel", val);
        }}
        onDropDownNameChange={(name) => setActivityLevelDisplay(name)}
        dropDownName={activityLevelDisplay}
        error={errors.activityLevel}
      />
```


## Related Issue

-
