### PR TITLE
[FIX] middleware logic: unauthenticated user now only see login page

### DIFF
--- a/apps/web/src/lib/supabase/middleware.ts
+++ b/apps/web/src/lib/supabase/middleware.ts
@@ -35,7 +35,7 @@ export default async function updateSession(request: NextRequest) {
   } = await supabase.auth.getUser();
 
   const path = request.nextUrl.pathname;
-  const locale = path.split("/")[1];
+  const locale = path.split("/")[1] == "th" ? "th" : "en";
   const loginPath = LOGIN_PATH(locale);
 
   // Redirect unauthenticated users to login

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -7,5 +7,8 @@ export async function proxy(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ["/:locale/auth/login"],
+  matcher: [
+    // Match all paths except /api, /_next, and static files
+    "/((?!api|_next|_next/static|_next/image|assets|Icons|favicon.ico|sw.js).*)",
+  ],
 };


### PR DESCRIPTION
## Description

- unauthenticated user now can only see login page
- authenticated user can't access login page anymore

## Changes Made

- proxy.ts change matcher
- lib/supabase/middleware.ts lock locale to th or en

## Related Issue

Closes #
